### PR TITLE
fix(zshrc): remove BAT_PAGER

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -115,7 +115,3 @@ bindkey '[D' backward-word  # alt+right
 export PATH="/usr/local/sbin:$PATH"
 export PATH="$HOME/.deno/bin:$PATH"
 export PATH="$HOME/go/bin:$PATH"
-
-# bat scroll support
-export BAT_PAGER="less -RF"
-


### PR DESCRIPTION
https://github.com/sharkdp/bat#using-a-different-pager

> `less` is used by default