### PR TITLE
feat: zsh-syntax-highlighting

### DIFF
--- a/dot_zplug.sh
+++ b/dot_zplug.sh
@@ -10,7 +10,7 @@ zplug "plugins/autojump", from:oh-my-zsh
 zplug "bigH/git-fuzzy", as:command, use:"bin/git-fuzzy"
 
 zplug "junegunn/fzf", use:"shell/*.zsh", defer:2
-zplug "zdharma-continuum/fast-syntax-highlighting", as:plugin, defer:2
+zplug "zsh-users/zsh-syntax-highlighting", defer:2
 zplug "zsh-users/zsh-autosuggestions", as:plugin, defer:2
 zplug 'zsh-users/zsh-completions', depth:1 # more completions
 


### PR DESCRIPTION
replaces fast-syntax-highlighting